### PR TITLE
Add a version identifier to the app title and bundled executable asset files

### DIFF
--- a/.github/workflows/bundle-with-pyinstaller.yaml
+++ b/.github/workflows/bundle-with-pyinstaller.yaml
@@ -77,6 +77,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
+      with:
+        ref: ${{ env.TAG_BRANCH }}
     - name: Set up Python
       uses: actions/setup-python@v3
       with:

--- a/.github/workflows/bundle-with-pyinstaller.yaml
+++ b/.github/workflows/bundle-with-pyinstaller.yaml
@@ -23,7 +23,8 @@ jobs:
         with:
           ref: ${{ env.TAG_BRANCH }} # defaults to the hash for tags. Need some sort of branch to do git commits (could also be the main branch). 
       # add the slugified (ie replace periods with dashes) to the version name to the saved output variables file
-      - id: save
+      - name: Save slugified version tag
+        id: save
         run: |
           slug_version="${GITHUB_REF_NAME//./-}" | sed -e "s/\./\-/g"
           echo "slug_version=${slug_version}" >> $GITHUB_OUTPUT

--- a/.github/workflows/bundle-with-pyinstaller.yaml
+++ b/.github/workflows/bundle-with-pyinstaller.yaml
@@ -5,6 +5,48 @@ on:
     tags:
       - "*"
 jobs:
+  tag_version:
+    name: Create version identifiers
+    runs-on: "ubuntu-latest"
+    # NOTE: slugified_version_name can now be used in other jobs (referenced via needs.tag_version.outputs.slugified_version_name)
+    permissions:
+      contents: write
+    outputs:
+      slug_version: ${{ steps.save.outputs.slug_version }}
+      # NOTE: ${GITHUB_REF_NAME//./-} is bash syntax for referencing the default environment $GITHUB_REF and replacing dots with dashes (in the form //<tobereplaced>/<replacewith>)
+      # NOTE: for comparison, double brackets like ${{ matrix.name }} is for referencing github workflow variables (and is not bash syntax)
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      # add the slugified (ie replace periods with dashes) to the version name to the saved output variables file
+      - id: save
+        run: |
+          slug_version="${GITHUB_REF_NAME//./-}" | sed -e "s/\./\-/g"
+          echo "slug_version=${slug_version}" >> $GITHUB_OUTPUT
+      # add git tag version to app script
+      - id: title_in_version
+        name: Add version number to app title
+        run: |
+          version="${GITHUB_REF_NAME}"
+          title_with_version="DSC Data Packaging Tool - alpha - ${version}"
+          echo $title_with_version
+          sed -i -e "s/DSC Data Packaging Tool*/${title_with_version}/g" dsc_pkg_tool.py
+          git add dsc_pkg_tool.py
+          git commit -m "Update app title to ${version}"
+          git push
+      - uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          # Optional. Commit message for the created commit.
+          # Defaults to "Apply automatic changes"
+          commit_message: "Update app title to ${{ github.ref_name }}"
+          # Optional. Options used by `git-commit`.
+          # See https://git-scm.com/docs/git-commit#_options
+          # commit_options: '--no-verify --signoff'
+
+          # Optional commit user and author settings
+          # commit_user_name: My GitHub Actions Bot # defaults to "github-actions[bot]"
+          # commit_user_email: my-github-actions-bot@example.org # defaults to "41898282+github-actions[bot]@users.noreply.github.com"
+          # commit_author: Author <actions@github.com> # defaults to author of the commit that triggered the run
   release:
     name: Create a release from a tag
     runs-on: "ubuntu-latest"
@@ -24,7 +66,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     permissions:
       contents: write
-    needs: release
+    needs: 
+      - release
+      - tag_version
     strategy:
       matrix:
         include:
@@ -43,15 +87,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-    # add git tag version to app script
-    # NOTE: ${GITHUB_REF//./-} is bash syntax for referencing the default environment $GITHUB_REF and replacing dots with dashes (in the form //<tobereplaced>/<replacewith>)
-    # NOTE: ${{ matrix.name }} is for referencing github workflow variables (and is not bash syntax)
-
-    - name: Add version number to app script
-      run: |
-        title="DSC Data Packaging Tool - alpha"
-        title_with_version="DSC Data Packaging Tool - alpha - ${GITHUBREF//./-}"
-        sed -i -e "s/${title}/${title_with_version}/g" dsc_pkg_tool.py 
     - name: Bundle EXE for mac  
       run: |
         pyinstaller --icon=heal-icon.ico --add-data="heal-icon.ico:." --collect-all pipe --hidden-import pipe --hidden-import pyreadstat._readstat_writer --hidden-import pyreadstat.worker --paths=. --debug=all --onefile dsc_pkg_tool.py
@@ -62,11 +97,11 @@ jobs:
       if: ${{matrix.name == 'windows' }} 
     - name: Zip exe (for windows) and no ext (for ubuntu/mac)
       run: |
-        zipped_file_name=dsc-pkg-tool-${{ matrix.name }}${GITHUB_REF//./-}.zip
+        zipped_file_name=dsc-pkg-tool-${{ matrix.name }}${{ needs.tag_version.outputs.slug_version }}.zip
         python -m zipfile -c  $zipped_file_name dist/dsc_pkg_tool.exe dist/dsc_pkg_tool
     - name: Release with bundles
       uses: softprops/action-gh-release@v1
       with:
         draft: true
         files: |
-          *dsc-pkg-tool-${{ matrix.name }}${GITHUB_REF//./-}.zip
+          *dsc-pkg-tool-${{ matrix.name }}${{ needs.tag_version.outputs.slug_version }}.zip

--- a/.github/workflows/bundle-with-pyinstaller.yaml
+++ b/.github/workflows/bundle-with-pyinstaller.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Save slugified version tag
         id: save
         run: |
-          slug_version="${GITHUB_REF_NAME//./-}" | sed -e "s/\./\-/g"
+          slug_version="${GITHUB_REF_NAME//./-}"
           echo "slug_version=${slug_version}" >> $GITHUB_OUTPUT
       # add git tag version to app script
       - id: title_in_version
@@ -95,10 +95,10 @@ jobs:
       if: ${{matrix.name == 'windows' }} 
     - name: Zip exe (for windows) and no ext (for ubuntu/mac)
       run: |
-        python -m zipfile -c  $dsc-pkg-tool-${{ matrix.name }}${{ needs.tag_version.outputs.slug_version }}.zip dist/dsc_pkg_tool.exe dist/dsc_pkg_tool
+        python -m zipfile -c dsc-pkg-tool-${{ matrix.name }}-${{ needs.tag_version.outputs.slug_version }}.zip dist/dsc_pkg_tool.exe dist/dsc_pkg_tool
     - name: Release with bundles
       uses: softprops/action-gh-release@v1
       with:
         draft: true
         files: |
-          *dsc-pkg-tool-${{ matrix.name }}${{ needs.tag_version.outputs.slug_version }}.zip
+          *dsc-pkg-tool-${{ matrix.name }}*.zip

--- a/.github/workflows/bundle-with-pyinstaller.yaml
+++ b/.github/workflows/bundle-with-pyinstaller.yaml
@@ -43,6 +43,15 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+    # add git tag version to app script
+    # NOTE: ${GITHUB_REF//./-} is bash syntax for referencing the default environment $GITHUB_REF and replacing dots with dashes (in the form //<tobereplaced>/<replacewith>)
+    # NOTE: ${{ matrix.name }} is for referencing github workflow variables (and is not bash syntax)
+
+    - name: Add version number to app script
+      run: |
+        title="DSC Data Packaging Tool - alpha"
+        title_with_version = "DSC Data Packaging Tool - alpha - ${GITHUBREF//./-}"
+        sed -i -e "s/${title}/${title_with_version}/g" dsc_pkg_tool.py 
     - name: Bundle EXE for mac  
       run: |
         pyinstaller --icon=heal-icon.ico --add-data="heal-icon.ico:." --collect-all pipe --hidden-import pipe --hidden-import pyreadstat._readstat_writer --hidden-import pyreadstat.worker --paths=. --debug=all --onefile dsc_pkg_tool.py
@@ -53,10 +62,11 @@ jobs:
       if: ${{matrix.name == 'windows' }} 
     - name: Zip exe (for windows) and no ext (for ubuntu/mac)
       run: |
-        python -m zipfile -c dsc-pkg-tool-${{ matrix.name }}.zip dist/dsc_pkg_tool.exe dist/dsc_pkg_tool
+        zipped_file_name=dsc-pkg-tool-${{ matrix.name }}${GITHUB_REF//./-}.zip
+        python -m zipfile -c  $zipped_file_name dist/dsc_pkg_tool.exe dist/dsc_pkg_tool
     - name: Release with bundles
       uses: softprops/action-gh-release@v1
       with:
         draft: true
         files: |
-          *dsc-pkg-tool-${{ matrix.name }}.zip
+          *dsc-pkg-tool-${{ matrix.name }}${GITHUB_REF//./-}.zip

--- a/.github/workflows/bundle-with-pyinstaller.yaml
+++ b/.github/workflows/bundle-with-pyinstaller.yaml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
       # add the slugified (ie replace periods with dashes) to the version name to the saved output variables file
       - id: save
         run: |

--- a/.github/workflows/bundle-with-pyinstaller.yaml
+++ b/.github/workflows/bundle-with-pyinstaller.yaml
@@ -35,7 +35,8 @@ jobs:
           version="${GITHUB_REF_NAME}"
           title_with_version="${APP_TITLE}${version}"
           echo $title_with_version
-          sed -i -e "s/DSC Data Packaging Tool*/${title_with_version}/g" dsc_pkg_tool.py
+          # replace the window title
+          sed -i -e "s/self.setWindowTitle(.*)/self.setWindowTitle(\"${title_with_version}\")/g" dsc_pkg_tool.py
 
           git config user.name ${{ github.triggering_actor }}
           git config user.email ${{ github.triggering_actor }}@users.noreply.github.com

--- a/.github/workflows/bundle-with-pyinstaller.yaml
+++ b/.github/workflows/bundle-with-pyinstaller.yaml
@@ -33,7 +33,7 @@ jobs:
         name: Add version number to app title
         run: |
           version="${GITHUB_REF_NAME}"
-          title_with_version="${APP_TITLE}${version}"
+          title_with_version="${APP_TITLE} ${version}"
           echo $title_with_version
           # replace the window title
           sed -i -e "s/self.setWindowTitle(.*)/self.setWindowTitle(\"${title_with_version}\")/g" dsc_pkg_tool.py

--- a/.github/workflows/bundle-with-pyinstaller.yaml
+++ b/.github/workflows/bundle-with-pyinstaller.yaml
@@ -5,7 +5,8 @@ on:
     tags:
       - "*"
 env:
-  TAG_BRANCH: tag-versions # See note below when this var is called
+  TAG_BRANCH: tag-versions # branch where the version-specific code is. See note below when this var is called
+  APP_TITLE: DSC Data Packaging Tool - alpha - #prefix for the title to be displayed in the app
 jobs:
   tag_version:
     name: Create version identifiers
@@ -19,6 +20,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ env.TAG_BRANCH }} # defaults to the hash for tags. Need some sort of branch to do git commits (could also be the main branch). 
       # add the slugified (ie replace periods with dashes) to the version name to the saved output variables file
       - id: save
         run: |
@@ -28,11 +31,8 @@ jobs:
       - id: title_in_version
         name: Add version number to app title
         run: |
-
-          git checkout -b $TAG_BRANCH # change branch to the branch defined for tags. Need some sort of branch to do git commits (could also be the main branch)
-          git push --set-upstream origin $TAG_BRANCH
           version="${GITHUB_REF_NAME}"
-          title_with_version="DSC Data Packaging Tool - alpha - ${version}"
+          title_with_version="${APP_TITLE}${version}"
           echo $title_with_version
           sed -i -e "s/DSC Data Packaging Tool*/${title_with_version}/g" dsc_pkg_tool.py
 
@@ -41,7 +41,7 @@ jobs:
 
           git add dsc_pkg_tool.py
           git commit -m "Automated update of app title to ${version}"
-          git push -u origin
+          git push -u origin $TAG_BRANCH
           
 
   release:
@@ -94,8 +94,7 @@ jobs:
       if: ${{matrix.name == 'windows' }} 
     - name: Zip exe (for windows) and no ext (for ubuntu/mac)
       run: |
-        zipped_file_name=dsc-pkg-tool-${{ matrix.name }}${{ needs.tag_version.outputs.slug_version }}.zip
-        python -m zipfile -c  $zipped_file_name dist/dsc_pkg_tool.exe dist/dsc_pkg_tool
+        python -m zipfile -c  $dsc-pkg-tool-${{ matrix.name }}${{ needs.tag_version.outputs.slug_version }}.zip dist/dsc_pkg_tool.exe dist/dsc_pkg_tool
     - name: Release with bundles
       uses: softprops/action-gh-release@v1
       with:

--- a/.github/workflows/bundle-with-pyinstaller.yaml
+++ b/.github/workflows/bundle-with-pyinstaller.yaml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - "*"
+env:
+  TAG_BRANCH: tag-versions # See note below when this var is called
 jobs:
   tag_version:
     name: Create version identifiers
@@ -12,10 +14,11 @@ jobs:
     outputs:
       slug_version: ${{ steps.save.outputs.slug_version }}
       # NOTE: ${GITHUB_REF_NAME//./-} is bash syntax for referencing the default environment $GITHUB_REF and replacing dots with dashes (in the form //<tobereplaced>/<replacewith>)
+      # NOTE: this is equivalent to ${{ github.ref_name }}
       # NOTE: for comparison, double brackets like ${{ matrix.name }} is for referencing github workflow variables (and is not bash syntax)
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       # add the slugified (ie replace periods with dashes) to the version name to the saved output variables file
       - id: save
         run: |
@@ -25,6 +28,9 @@ jobs:
       - id: title_in_version
         name: Add version number to app title
         run: |
+
+          git checkout -b $TAG_BRANCH # change branch to the branch defined for tags. Need some sort of branch to do git commits (could also be the main branch)
+          git push --set-upstream origin $TAG_BRANCH
           version="${GITHUB_REF_NAME}"
           title_with_version="DSC Data Packaging Tool - alpha - ${version}"
           echo $title_with_version
@@ -34,7 +40,7 @@ jobs:
           git config user.email ${{ github.triggering_actor }}@users.noreply.github.com
 
           git add dsc_pkg_tool.py
-          git commit -m "Update app title to ${version}"
+          git commit -m "Automated update of app title to ${version}"
           git push -u origin
           
 

--- a/.github/workflows/bundle-with-pyinstaller.yaml
+++ b/.github/workflows/bundle-with-pyinstaller.yaml
@@ -50,7 +50,7 @@ jobs:
     - name: Add version number to app script
       run: |
         title="DSC Data Packaging Tool - alpha"
-        title_with_version = "DSC Data Packaging Tool - alpha - ${GITHUBREF//./-}"
+        title_with_version="DSC Data Packaging Tool - alpha - ${GITHUBREF//./-}"
         sed -i -e "s/${title}/${title_with_version}/g" dsc_pkg_tool.py 
     - name: Bundle EXE for mac  
       run: |

--- a/.github/workflows/bundle-with-pyinstaller.yaml
+++ b/.github/workflows/bundle-with-pyinstaller.yaml
@@ -9,8 +9,6 @@ jobs:
     name: Create version identifiers
     runs-on: "ubuntu-latest"
     # NOTE: slugified_version_name can now be used in other jobs (referenced via needs.tag_version.outputs.slugified_version_name)
-    permissions:
-      contents: write
     outputs:
       slug_version: ${{ steps.save.outputs.slug_version }}
       # NOTE: ${GITHUB_REF_NAME//./-} is bash syntax for referencing the default environment $GITHUB_REF and replacing dots with dashes (in the form //<tobereplaced>/<replacewith>)
@@ -18,8 +16,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.head_ref }}
       # add the slugified (ie replace periods with dashes) to the version name to the saved output variables file
       - id: save
         run: |
@@ -33,19 +29,15 @@ jobs:
           title_with_version="DSC Data Packaging Tool - alpha - ${version}"
           echo $title_with_version
           sed -i -e "s/DSC Data Packaging Tool*/${title_with_version}/g" dsc_pkg_tool.py
-      - uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          # Optional. Commit message for the created commit.
-          # Defaults to "Apply automatic changes"
-          commit_message: "Update app title to ${{ github.ref_name }}"
-          # Optional. Options used by `git-commit`.
-          # See https://git-scm.com/docs/git-commit#_options
-          # commit_options: '--no-verify --signoff'
 
-          # Optional commit user and author settings
-          # commit_user_name: My GitHub Actions Bot # defaults to "github-actions[bot]"
-          # commit_user_email: my-github-actions-bot@example.org # defaults to "41898282+github-actions[bot]@users.noreply.github.com"
-          # commit_author: Author <actions@github.com> # defaults to author of the commit that triggered the run
+          git config user.name ${{ github.triggering_actor }}
+          git config user.email ${{ github.triggering_actor }}@users.noreply.github.com
+
+          git add dsc_pkg_tool.py
+          git commit -m "Update app title to ${version}"
+          git push -u origin
+          
+
   release:
     name: Create a release from a tag
     runs-on: "ubuntu-latest"

--- a/.github/workflows/bundle-with-pyinstaller.yaml
+++ b/.github/workflows/bundle-with-pyinstaller.yaml
@@ -31,9 +31,6 @@ jobs:
           title_with_version="DSC Data Packaging Tool - alpha - ${version}"
           echo $title_with_version
           sed -i -e "s/DSC Data Packaging Tool*/${title_with_version}/g" dsc_pkg_tool.py
-          git add dsc_pkg_tool.py
-          git commit -m "Update app title to ${version}"
-          git push
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:
           # Optional. Commit message for the created commit.


### PR DESCRIPTION
Adds the version tag as a suffix to zip files and to the title within the app

NOTE: See below for workflow code snippet values one may want to change:

```yaml

env:
  TAG_BRANCH: tag-versions # branch where the version-specific code is. See note below when this var is called
  APP_TITLE: DSC Data Packaging Tool - alpha - #prefix for the title to be displayed in the app

```