### PR TITLE
Finish update fx

### DIFF
--- a/dsc_pkg_utils.py
+++ b/dsc_pkg_utils.py
@@ -362,7 +362,7 @@ def layoutInLayoutDelete(containerLayout,layoutInLayout):
 #             self.containerLayout.removeItem(layout_item)
 #             break
 
-def get_added_resource_paths(self):
+def get_added_resource_paths(self, latestEntryOnly=False, includeRemovedEntry=True):
 #def get_added_resource_paths():
     
     getDir = self.workingDataPkgDir
@@ -378,6 +378,19 @@ def get_added_resource_paths(self):
         print(resourceTrackerDf.columns)
 
         if "path" in resourceTrackerDf.columns:
+
+            resourceTrackerDf["annotationModDateTime"] = pd.to_datetime(resourceTrackerDf["annotationModDateTime"])
+            
+            # sort by date-time (ascending), then drop duplicates of, keeping the last/latest instance of each path's occurrence
+            # to get the latest annotation entry
+            resourceTrackerDf.sort_values(by=["annotationModDateTime"],ascending=True,inplace=True)
+
+            if latestEntryOnly:
+                resourceTrackerDf.drop_duplicates(subset=["path"],keep="last",inplace=True)
+
+            if not includeRemovedEntry:
+                if "removed" in resourceTrackerDf.columns:
+                    resourceTrackerDf = resourceTrackerDf[resourceTrackerDf["removed"] == 0]
 
             #experimentTrackerDf["experimentName"] = experimentTrackerDf["experimentName"].astype(str)
             resourcePathSeries = resourceTrackerDf["path"].astype(str)
@@ -439,7 +452,7 @@ def get_resources_share_status(self):
     if os.path.isfile(getShareStatus):
         shareStatusDf = pd.read_csv(getShareStatus)
         shareStatusDf.fillna("", inplace = True)
-        pd.to_datetime(shareStatusDf["date-time"])
+        shareStatusDf["date-time"] = pd.to_datetime(shareStatusDf["date-time"])
         
         print(shareStatusDf)
         print(shareStatusDf.columns)

--- a/dsc_pkg_utils.py
+++ b/dsc_pkg_utils.py
@@ -386,7 +386,7 @@ def get_added_resource_paths(self, latestEntryOnly=False, includeRemovedEntry=Tr
             resourceTrackerDf.sort_values(by=["annotationModDateTime"],ascending=True,inplace=True)
 
             if latestEntryOnly:
-                resourceTrackerDf.drop_duplicates(subset=["path"],keep="last",inplace=True)
+                resourceTrackerDf.drop_duplicates(subset=["resourceId"],keep="last",inplace=True)
 
             if not includeRemovedEntry:
                 if "removed" in resourceTrackerDf.columns:

--- a/layout_resourcetrkresourcestoaddwidget.py
+++ b/layout_resourcetrkresourcestoaddwidget.py
@@ -727,8 +727,14 @@ class ResourcesToAddWindow(QtWidgets.QMainWindow):
         if not dsc_pkg_utils.getWorkingDataPkgDir(self=self):
             return
 
+        # check self.schemaVersion against version in operational schema version file 
+        # if no operational schema version file exists OR 
+        # if version in operational schema version file is less than self.schemaVersion 
+        # return with message that update of tracker version is needed before new annotations can be added
+        if not dsc_pkg_utils.checkTrackerCreatedSchemaVersionAgainstCurrent(self=self,trackerTypeFileNameString="resource-tracker",trackerTypeMessageString="Resource Tracker"):
+            return
+            
         # experiment tracker is needed to populate the enum of experimentNameBelongsTo schema property so perform some checks
-
         # check that experiment tracker exists in working data pkg dir, if not, return
         if not os.path.exists(os.path.join(self.workingDataPkgDir,"heal-csv-experiment-tracker.csv")):
             messageText = "<br>There is no Experiment Tracker file in your working Data Package Directory; Your working Data Package Directory must contain an Experiment Tracker file to proceed. If you need to change your working Data Package Directory or create a new one, head to the \"Data Package\" tab >> \"Create or Continue Data Package\" sub-tab to set a new working Data Package Directory or create a new one. <br>"

--- a/layout_resourcetrkresourcestoaddwidget.py
+++ b/layout_resourcetrkresourcestoaddwidget.py
@@ -258,7 +258,7 @@ class ResourcesToAddWindow(QtWidgets.QMainWindow):
         
         ##############################################################################################
         print("getting resources already added to resource tracker")
-        resourcePathList = dsc_pkg_utils.get_added_resource_paths(self=self)
+        resourcePathList = dsc_pkg_utils.get_added_resource_paths(self=self,latestEntryOnly=True, includeRemovedEntry=False)
         
         if not resourcePathList:
                    
@@ -733,7 +733,7 @@ class ResourcesToAddWindow(QtWidgets.QMainWindow):
         # return with message that update of tracker version is needed before new annotations can be added
         if not dsc_pkg_utils.checkTrackerCreatedSchemaVersionAgainstCurrent(self=self,trackerTypeFileNameString="resource-tracker",trackerTypeMessageString="Resource Tracker"):
             return
-            
+
         # experiment tracker is needed to populate the enum of experimentNameBelongsTo schema property so perform some checks
         # check that experiment tracker exists in working data pkg dir, if not, return
         if not os.path.exists(os.path.join(self.workingDataPkgDir,"heal-csv-experiment-tracker.csv")):


### PR DESCRIPTION
- add check on tracker up to date when adding to tracker from check resources to add tab
- when getting list of resources to add for that tab, compare the resources to add list against only latest entry for a resource, where entry has not been removed (instead of all entries in resource tracker regardless of if they are the latest entry or have been removed by user)