### PR TITLE
set resultsTrackerSstemList to empty if no results  trackers are in t…

### DIFF
--- a/pkg_shareable_data.py
+++ b/pkg_shareable_data.py
@@ -215,6 +215,9 @@ def createShareableDataPkg(workingDataPkgDir,flavor="shell",byDate="1/1/2099",sh
                         resultsTrackerEntriesTransformedDfList.append(resultsTrackerEntries)
                         resultsTrackerStemList.append(resultsTrackerStem)
 
+                else: 
+                    resultsTrackerStemList = []
+
 
                 filesToKeep = resourceTrackerEntriesToShare["path"].tolist()
                 filesToKeep.extend([os.path.join(workingDataPkgDir,"heal-csv-experiment-tracker.csv")])


### PR DESCRIPTION
…he files to share list

fixes issue where tool crashes when creating shareable data pkg if data pkg does not contain at least one results tracker that is added to resource tracker as to be shared