### PR TITLE
Update bundle-with-pyinstaller.yaml - try getting around build fail f…

### DIFF
--- a/.github/workflows/bundle-with-pyinstaller.yaml
+++ b/.github/workflows/bundle-with-pyinstaller.yaml
@@ -83,7 +83,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v3
       with:
-        python-version: "3.10"
+        python-version: "3.9"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
…or macos exe by using python 3.9 instead of 3.10 - pyqt5 tools only compatible with python 3.5-3.9